### PR TITLE
[fix]: #16 requirements.dev.txtをpip install前にコピーするよう修正

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -35,6 +35,7 @@ RUN apt-get update && \
     zsh && \
     rm -rf /var/lib/apt/lists/*
 
+COPY requirements.dev.txt ./
 RUN pip install --no-cache-dir -r requirements.dev.txt
 # RUN pip install --no-cache-dir black django django-stubs flake8 flake8-bugbear flake8-pytest-style isort mypy pytest pytest-cov pytest-django pytest-xdist yamllint 
 


### PR DESCRIPTION
`make up-d` コマンド中のビルド失敗を解決するため、Dockerfile.devに `requirements.dev.txt` のコピー行を明示的に追加しました。これにより、pip installを実行する前にファイルがDockerイメージ内に存在することが保証され、依存関係が見つからないというエラーを防ぎます。

close #16

## コミットの種類

<!-- このプルリクエストに最も当てはまるコミットの種類を選択してください。 -->

- [ ] feat: 新機能や機能の追加
- [x] fix: バグの修正
- [ ] docs: ドキュメントの変更
- [ ] style: コードスタイルの調整（ロジックの変更は無し）
- [ ] refactor: バグを修正したり機能を追加せずに、コードをリファクタリング
- [ ] test: テストコードの追加や修正
- [ ] chore: ビルドプロセスやツールの変更
- [ ] other: 上記のいずれにも当てはまらないその他の変更

## このプルリクエストの内容

<!-- このPRで達成したいことや、具体的な変更内容を記述してください。 -->

## 変更による影響

<!-- この変更がアプリケーションやプロジェクトに与える影響を、可能な限り詳細に記述してください。 -->

## テスト手順

<!-- この変更をテストする手順を記述してください。必要なコマンド、環境設定、期待する結果などを含めてください。 -->

## スクリーンショット

<!-- 変更内容を示すのに役立つスクリーンショットがあれば、ここに追加してください。 -->

## その他のノート

<!-- このPRに関連するその他の情報があれば、ここに追加してください。 -->
